### PR TITLE
Add push-dist

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,23 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wyvox/action-setup-pnpm@v2
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: ember-velcro


### PR DESCRIPTION
This enables folks to point at git when stuff isn't released yet

```
"ember-velcro": "github:CrowdStrike/ember-velcro#dist"

```