### PR TITLE
Allow floaty bit to hide appropriately

### DIFF
--- a/.changeset/fair-taxis-lay.md
+++ b/.changeset/fair-taxis-lay.md
@@ -1,0 +1,5 @@
+---
+"ember-velcro": patch
+---
+
+Fixes an issue with visibility

--- a/ember-velcro/src/modifiers/velcro.ts
+++ b/ember-velcro/src/modifiers/velcro.ts
@@ -88,11 +88,15 @@ export default class VelcroModifier extends Modifier<Signature> {
         strategy,
       });
 
+      const { referenceHidden } = middlewareData.hide;
+
       Object.assign(floatingElement.style, {
         top: `${y}px`,
         left: `${x}px`,
         margin: 0,
+        visibility: referenceHidden ? 'hidden' : 'visible',
       });
+
       setVelcroData?.(middlewareData.metadata);
     };
 


### PR DESCRIPTION
Demo: https://codesandbox.io/s/xenodochial-monad-j4l6sz?file=/src/index.js:739-796

This is a fix that was mistakenly removed from here: https://github.com/CrowdStrike/ember-velcro/pull/124/files#diff-65d380c49bf5cb7ddbb835f8a073a1e99834b354026842912b1d6f36368064e1L94


This PR adds it back.