### PR TITLE
Add a loose mode integration test

### DIFF
--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -5,7 +5,6 @@ const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   let releaseVersion = await getChannelURL('release');
-  let embroiderVersion = '^1.9.0';
 
   return {
     usePnpm: true,
@@ -62,9 +61,6 @@ module.exports = async function () {
         name: 'ember-release + embroider-safe',
         npm: {
           devDependencies: {
-            '@embroider/core': embroiderVersion,
-            '@embroider/webpack': embroiderVersion,
-            '@embroider/compat': embroiderVersion,
             'ember-source': releaseVersion,
           },
         },
@@ -73,9 +69,6 @@ module.exports = async function () {
         name: 'ember-release + embroider-optimized',
         npm: {
           devDependencies: {
-            '@embroider/core': embroiderVersion,
-            '@embroider/webpack': embroiderVersion,
-            '@embroider/compat': embroiderVersion,
             'ember-source': releaseVersion,
           },
         },
@@ -84,9 +77,6 @@ module.exports = async function () {
         name: 'ember-lts-3.28 + embroider-optimized',
         npm: {
           devDependencies: {
-            '@embroider/core': embroiderVersion,
-            '@embroider/webpack': embroiderVersion,
-            '@embroider/compat': embroiderVersion,
             'ember-source': '~3.28.0',
           },
         },
@@ -95,9 +85,6 @@ module.exports = async function () {
         name: 'ember-lts-4.4 + embroider-optimized',
         npm: {
           devDependencies: {
-            '@embroider/core': embroiderVersion,
-            '@embroider/webpack': embroiderVersion,
-            '@embroider/compat': embroiderVersion,
             'ember-source': '~4.4.0',
           },
         },

--- a/test-app/tests/integration/components/loose-mode-velcro-test.ts
+++ b/test-app/tests/integration/components/loose-mode-velcro-test.ts
@@ -1,0 +1,38 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { resetTestingContainerDimensions } from '../velcro-test-helpers';
+
+module('Integration | Component | velcro (loose mode)', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    resetTestingContainerDimensions();
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Velcro as |velcro|>
+        <div id="hook" {{velcro.hook}} style="width: 200px; height: 40px">
+          {{velcro.data.rects.reference.width}}
+          {{velcro.data.rects.reference.height}}
+        </div>
+        <div id="loop" {{velcro.loop}} style="width: 200px; height: 400px">
+          {{velcro.data.rects.floating.width}}
+          {{velcro.data.rects.floating.height}}
+        </div>
+      </Velcro>
+    `);
+
+    assert.dom('#hook').hasText('200 40', 'reference element has expected dimensions');
+    assert.dom('#loop').hasText('200 400', 'floating element has expected dimensions');
+    assert.dom('#loop').hasAttribute('style');
+    assert.dom('#loop').hasStyle({
+      position: 'fixed',
+      top: '40px',
+      left: '0px',
+    });
+  });
+});


### PR DESCRIPTION
This verifies that the component can still be used in loose mode templates.

This is actually a failing test since this doesn't seem to work in Embroider (v3) apps. The problem is related to the "nested" component layout usage in v2 addons. It's not clear yet if this is a bug in Embroider, or something that isn't supported in v2 addons.

Discord discussion: https://discord.com/channels/480462759797063690/1147119814444318863