### PR TITLE
Deprecate ember-velcro

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The code for ember-velcro has been copied to `ember-primitives` and improved there:
 
 GitHub: https://github.com/universal-ember/ember-primitives/
-Docs: https://ember-primitives.pages.dev/5-floaty-bits/popover.md
+Docs: https://ember-primitives.pages.dev/5-floaty-bits/floating-ui.md
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# ⚠️ Deprecated
+
+The code for ember-velcro has been copied to `ember-primitives` and improved there:
+
+GitHub: https://github.com/universal-ember/ember-primitives/
+Docs: https://ember-primitives.pages.dev/5-floaty-bits/popover.md
+
+---------------------------------------
+
 Ember Velcro
 ==============================================================================
 


### PR DESCRIPTION
<3 Good code, but I'm maintining the code now in ember-primitives.

My hope is to also one day phase out the popover once the platform (and browsers have sufficient coverage) has the needed html/css apis to do the same work.

